### PR TITLE
hotfix: proper annotation callable for agent core logic

### DIFF
--- a/src/agent/core.py
+++ b/src/agent/core.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 from src.prompts import SYSTEM_PROMPT_BASIC
 from src.providers import LLMProvider
 from src.providers.models import Message
@@ -10,10 +12,10 @@ class CodeAgent:
         self,
         provider: LLMProvider,
         system_prompt: str | None = None,
-        on_conversation_update: callable | None = None,
+        on_conversation_update: Callable | None = None,
         tool_registry=None,
         tool_permissions=None,
-        on_tool_call: callable | None = None,
+        on_tool_call: Callable | None = None,
         is_subagent: bool = False,
     ):
         self.provider = provider


### PR DESCRIPTION
This pull request makes a small but important improvement to the type annotations in the `src/agent/core.py` file. Specifically, it replaces the use of the lowercase `callable` with the proper `Callable` type from the `typing` module for the `on_conversation_update` and `on_tool_call` parameters in the class constructor, and adds the necessary import for `Callable`.

- Type annotation improvements:
  * Replaced `callable` with `Callable` from the `typing` module for the `on_conversation_update` and `on_tool_call` parameters in the constructor, and added the import statement for `Callable`. [[1]](diffhunk://#diff-e992a419ebd905f52584d3b68157803ce7c8a57d66b0a140b2db3b518fc85895R1-R2) [[2]](diffhunk://#diff-e992a419ebd905f52584d3b68157803ce7c8a57d66b0a140b2db3b518fc85895L13-R18)